### PR TITLE
Fix issue #4

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,20 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "rollup": "^0.57.1",
-    "rollup-plugin-svelte": "^4.1.0",
-    "svelte": "^1.60.0"
+    "rollup": "^0.67.4",
+    "rollup-plugin-svelte": "^4.4.0",
+    "svelte": "^2.15.3"
   },
   "keywords": [
-    "svelte"
+    "javascript",
+    "svelte",
+    "svelte-components",
+    "autocomplete",
+    "auto complete",
+    "autosuggest",
+    "auto suggest",
+    "typeahead",
+    "type ahead"
   ],
   "files": [
     "src",
@@ -30,16 +38,5 @@
   "bugs": {
     "url": "https://github.com/elcobvg/svelte-autocomplete/issues"
   },
-  "homepage": "https://github.com/elcobvg/svelte-autocomplete#readme",
-  "keywords": [
-    "javascript",
-    "svelte",
-    "svelte-components",
-    "autocomplete",
-    "auto complete",
-    "autosuggest",
-    "auto suggest",
-    "typeahead",
-    "type ahead"
-  ]
+  "homepage": "https://github.com/elcobvg/svelte-autocomplete#readme"
 }

--- a/package.json
+++ b/package.json
@@ -7,13 +7,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "rollup": "^0.57.1",
-    "rollup-plugin-svelte": "^4.1.0",
-    "svelte": "^1.60.0"
+    "rollup": "^0.67.4",
+    "rollup-plugin-svelte": "^4.4.0",
+    "svelte": "^2.15.3"
   },
-  "keywords": [
-    "svelte"
-  ],
   "files": [
     "src",
     "dist"

--- a/package.json
+++ b/package.json
@@ -7,20 +7,12 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "rollup": "^0.67.4",
-    "rollup-plugin-svelte": "^4.4.0",
-    "svelte": "^2.15.3"
+    "rollup": "^0.57.1",
+    "rollup-plugin-svelte": "^4.1.0",
+    "svelte": "^1.60.0"
   },
   "keywords": [
-    "javascript",
-    "svelte",
-    "svelte-components",
-    "autocomplete",
-    "auto complete",
-    "autosuggest",
-    "auto suggest",
-    "typeahead",
-    "type ahead"
+    "svelte"
   ],
   "files": [
     "src",
@@ -38,5 +30,16 @@
   "bugs": {
     "url": "https://github.com/elcobvg/svelte-autocomplete/issues"
   },
-  "homepage": "https://github.com/elcobvg/svelte-autocomplete#readme"
+  "homepage": "https://github.com/elcobvg/svelte-autocomplete#readme",
+  "keywords": [
+    "javascript",
+    "svelte",
+    "svelte-components",
+    "autocomplete",
+    "auto complete",
+    "autosuggest",
+    "auto suggest",
+    "typeahead",
+    "type ahead"
+  ]
 }


### PR DESCRIPTION
I was experiencing the issue explained in #4 , also with parceljs when, importing the component through npm to a svelte v2 project. I suppose there are some breaking changes when compiling, but I'm new to svelte so I don't really know.

source 

```html
  <input
    type="text"
    class="{class}"
    {name}
    {placeholder}
    {required}
    {disabled}
    value="{value || ''}"
    autocomplete="{name}"
    bind:value="search"
    on:input="onChange(event)"
    on:focus="fire('focus', event)"
    on:blur="fire('blur', event)"
    on:keydown="onKeyDown(event)"
    ref:input
  >
```

In v1.6 the following code was generated which causes the exception when importing my svelte v2.x project:

```javascript
				setAttribute(input, "type", "text");
				input.className = "{class} svelte-1yo2r3";
				setAttribute(input, "{name}", true);
				setAttribute(input, "{placeholder}", true);
				setAttribute(input, "{required}", true);
				setAttribute(input, "{disabled}", true);
```

Recompiling the component with v2.x.x yields the following.

```javascript
				input.className = "" + ctx.class + " svelte-18gzdmd";
				input.name = ctx.name;
				input.placeholder = ctx.placeholder;
				input.required = ctx.required;
				input.disabled = ctx.disabled;

```
Maybe building and publishing the component again in npm will resolve this issue.

Another thing I had to struggle with parceljs is async/await as seen here [#1762](https://github.com/parcel-bundler/parcel/issues/1762)

In my project, as is a proof of concept, I ended up instructing parceljs/babel not to transpile aync/await by making this entry in package.json. This made parceljs download the presets-env dependency and target async/await browsers.

```
{
  ...
  "browserslist": [
    "last 2 Chrome versions"
  ]
}
```

Great component, I was looking for a real component to learn a little bit more about svelte.

Germán